### PR TITLE
Fixing The Release (sonatypeProfileName was slightly incorrect)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@
 
 import Dependencies._
 
-ThisBuild / name := "balta"
 ThisBuild / organization := "za.co.absa"
 
 lazy val scala211 = "2.11.12"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@
 
 import Dependencies._
 
-ThisBuild / organization := "za.co.absa.balta"
+ThisBuild / name := "balta"
+ThisBuild / organization := "za.co.absa"
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.18"
@@ -25,6 +26,8 @@ lazy val scala213 = "2.13.11"
 lazy val supportedScalaVersions: Seq[String] = Seq(scala211, scala212 , scala213)
 
 ThisBuild / scalaVersion := scala212
+
+ThisBuild / versionScheme := Some("early-semver")
 
 lazy val balta = (project in file("balta"))
   .settings(


### PR DESCRIPTION
Adding missed versionScheme and changing organization to be za.co.absa; this will be used for the sonatypeProfileName.