### PR TITLE
#33: Make execution of function without verification easier

### DIFF
--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -46,11 +46,21 @@ sealed abstract class DBFunction private(functionName: String,
   }
 
   /**
-   * Executes the function.
+   * Executes the function without caring about the result. The goal is the side-effect of the function.
    * @param connection  - the database connection
    */
-  def execute()(implicit connection: DBConnection): Unit = {
+  def perform()(implicit connection: DBConnection): Unit = {
     execute("")(_ => ())
+  }
+
+  /**
+   * Executes the function without any verification proceudre. It instantiate the function result(s) and return them in
+   * a list.
+   * @param orderBy     - the clause how to order the function result, if empty, default ordering is preserved
+   * @param connection  - the database connection
+   */
+  def getResult(orderBy: String = "")(implicit connection: DBConnection): List[QueryResultRow] = {
+    execute("")(_.toList)
   }
 
   /**

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -54,7 +54,7 @@ sealed abstract class DBFunction private(functionName: String,
   }
 
   /**
-   * Executes the function without any verification proceudre. It instantiate the function result(s) and return them in
+   * Executes the function without any verification procedure. It instantiates the function result(s) and returns them in
    * a list.
    * @param orderBy     - the clause how to order the function result, if empty, default ordering is preserved
    * @param connection  - the database connection

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -46,6 +46,14 @@ sealed abstract class DBFunction private(functionName: String,
   }
 
   /**
+   * Executes the function.
+   * @param connection  - the database connection
+   */
+  def execute()(implicit connection: DBConnection): Unit = {
+    execute("")(_ => Unit)
+  }
+
+  /**
    *  Executes the function and verifies the result via the verify function.
    *
    * @param verify      - the function that verifies the result

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -50,7 +50,7 @@ sealed abstract class DBFunction private(functionName: String,
    * @param connection  - the database connection
    */
   def execute()(implicit connection: DBConnection): Unit = {
-    execute("")(_ => Unit)
+    execute("")(_ => ())
   }
 
   /**

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -60,7 +60,7 @@ sealed abstract class DBFunction private(functionName: String,
    * @param connection  - the database connection
    */
   def getResult(orderBy: String = "")(implicit connection: DBConnection): List[QueryResultRow] = {
-    execute("")(_.toList)
+    execute(orderBy)(_.toList)
   }
 
   /**

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -57,6 +57,9 @@ sealed abstract class DBFunction private(functionName: String,
    * Executes the function without any verification procedure. It instantiates the function result(s) and returns them in
    * a list.
    * @param orderBy     - the clause how to order the function result, if empty, default ordering is preserved
+   *                    examples:
+   *                      * "product_id DESC"
+   *                      * "product_name, import_date DESC"
    * @param connection  - the database connection
    */
   def getResult(orderBy: String = "")(implicit connection: DBConnection): List[QueryResultRow] = {
@@ -79,6 +82,9 @@ sealed abstract class DBFunction private(functionName: String,
    *  Executes the function and verifies the result via the verify function.
    *
    * @param orderBy     - the clause how to order the function result
+   *                    examples:
+   *                      * "product_id DESC"
+   *                      * "product_name, import_date DESC"
    * @param verify      - the function that verifies the result
    * @param connection  - the database connection
    * @tparam R          - the type of the result that is returned by the verify function


### PR DESCRIPTION
* `DBFunction.perfrom` added, intention to just execute the function without care for result, just the side-effect
* new function `DBFunction.getResult` which execute the function and returns the list of its outputs

Note:
Yes, `getResult` could also have a version to return a _Scala_ case class list, as #13 suggests. But it's beyond the scope of this simple PR.

Closes #33
