### PR TITLE
#43: DBTestSuite: parametrize persist_data into constructor

### DIFF
--- a/.github/workflows/check_pr_release_notes.yml
+++ b/.github/workflows/check_pr_release_notes.yml
@@ -69,7 +69,10 @@ jobs:
         if: steps.pr_info.outputs.skip_check == 'false'
         run: |
           # Extract the body from the previous step
-          PR_BODY="${{ steps.pr_info.outputs.pr_body }}"
+          PR_BODY=$(cat <<-'EOF'
+          ${{ steps.pr_info.outputs.pr_body }}
+          EOF
+          )
 
           # Check if "Release Notes:" exists
           if ! echo "$PR_BODY" | grep -q '${{ env.RLS_NOTES_TAG_REGEX }}'; then

--- a/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
@@ -49,7 +49,9 @@ abstract class DBTestSuite(val persistDataOverride: Option[Boolean] = None) exte
    * This is the connection info for the DB. It can be overridden in the derived classes to provide specific credentials
    */
   protected lazy val connectionInfo: ConnectionInfo = {
-    persistDataOverride.map(overrideValue => connectionInfo.copy(persistData = overrideValue)).getOrElse(connectionInfo)
+    val connectionInfoFromConfig = readConnectionInfoFromConfig
+    persistDataOverride.map(overrideValue => connectionInfoFromConfig.copy(persistData = overrideValue))
+      .getOrElse(connectionInfoFromConfig)
   }
 
   /**
@@ -152,7 +154,7 @@ abstract class DBTestSuite(val persistDataOverride: Option[Boolean] = None) exte
   }
 
   // private functions
-  private def readConnectionInfoFromConfig: ConnectionInfo = {
+  protected def readConnectionInfoFromConfig: ConnectionInfo = {
     val properties = new Properties()
     properties.load(getClass.getResourceAsStream("/database.properties"))
 

--- a/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
@@ -35,7 +35,11 @@ import java.util.Properties
  * * easy access to DB tables and functions
  * * the now() function that returns the current transaction time in the DB
  */
-abstract class DBTestSuite extends AnyFunSuite {
+abstract class DBTestSuite(val persistDataOverride: Option[Boolean] = None) extends AnyFunSuite {
+
+  def this(persistDataOverride: Boolean) {
+    this(Some(persistDataOverride));
+  }
 
   /* the DB connection is ``lazy`, so it actually can be created only when needed and therefore the credentials
   overridden in the successor */
@@ -44,7 +48,9 @@ abstract class DBTestSuite extends AnyFunSuite {
   /**
    * This is the connection info for the DB. It can be overridden in the derived classes to provide specific credentials
    */
-  protected lazy val connectionInfo: ConnectionInfo = readConnectionInfoFromConfig
+  protected lazy val connectionInfo: ConnectionInfo = {
+    persistDataOverride.map(overrideValue => connectionInfo.copy(persistData = overrideValue)).getOrElse(connectionInfo)
+  }
 
   /**
    * This is an enhanced test function that automatically rolls back the transaction after the test is finished

--- a/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/DBTestSuite.scala
@@ -154,9 +154,15 @@ abstract class DBTestSuite(val persistDataOverride: Option[Boolean] = None) exte
   }
 
   // private functions
-  protected def readConnectionInfoFromConfig: ConnectionInfo = {
+  private def readConnectionInfoFromConfig: ConnectionInfo = {
+    DBTestSuite.connectionInfoFromResourceConfig("/database.properties")
+  }
+}
+
+object DBTestSuite {
+  def connectionInfoFromResourceConfig(resourceName: String): ConnectionInfo = {
     val properties = new Properties()
-    properties.load(getClass.getResourceAsStream("/database.properties"))
+    properties.load(getClass.getResourceAsStream(resourceName))
 
     ConnectionInfo(
       dbUrl = properties.getProperty("test.jdbc.url"),

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/DBFunction.scala
@@ -46,6 +46,27 @@ sealed abstract class DBFunction private(functionName: String,
   }
 
   /**
+   * Executes the function without caring about the result. The goal is the side-effect of the function.
+   * @param connection  - the database connection
+   */
+  def perform()(implicit connection: DBConnection): Unit = {
+    execute("")(_ => ())
+  }
+
+  /**
+   * Executes the function without any verification procedure. It instantiates the function result(s) and returns them in
+   * a list.
+   * @param orderBy     - the clause how to order the function result, if empty, default ordering is preserved
+   *                    examples:
+   *                      * "product_id DESC"
+   *                      * "product_name, import_date DESC"
+   * @param connection  - the database connection
+   */
+  def getResult(orderBy: String = "")(implicit connection: DBConnection): List[QueryResultRow] = {
+    execute(orderBy)(_.toList)
+  }
+
+  /**
    *  Executes the function and verifies the result via the verify function.
    *
    * @param verify      - the function that verifies the result
@@ -61,6 +82,9 @@ sealed abstract class DBFunction private(functionName: String,
    *  Executes the function and verifies the result via the verify function.
    *
    * @param orderBy     - the clause how to order the function result
+   *                    examples:
+   *                      * "product_id DESC"
+   *                      * "product_name, import_date DESC"
    * @param verify      - the function that verifies the result
    * @param connection  - the database connection
    * @tparam R          - the type of the result that is returned by the verify function

--- a/balta/src/test/scala/za/co/absa/db/balta/DBTestSuiteUnitTests.scala
+++ b/balta/src/test/scala/za/co/absa/db/balta/DBTestSuiteUnitTests.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.db.balta
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class DBTestSuiteUnitTests extends AnyFunSuiteLike {
+  test("connectionInfoFromResourceConfig reads local resource file correctly") {
+    val connectionInfo = DBTestSuite.connectionInfoFromResourceConfig("/database.properties")
+    assert(connectionInfo.dbUrl == "jdbc:postgresql://localhost:5432/mag_db")
+    assert(connectionInfo.username == "mag_owner")
+    assert(connectionInfo.password == "changeme")
+    assert(!connectionInfo.persistData)
+  }
+}


### PR DESCRIPTION
* make it easy to override data persistence in the `DBTestSuite` class, without the need to override functions.

Closes #43 

Release Notes:
- easier override of the data persistence within `DBTestSuite` instance via constructor parameter (no need to function overrides)
