### PR TITLE
Make field and parameter names case-insensitive

### DIFF
--- a/balta/src/main/scala/za/co/absa/db/balta/classes/QueryResultRow.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/QueryResultRow.scala
@@ -22,6 +22,7 @@ import za.co.absa.db.balta.implicits.MapImplicits.MapEnhancements
 import java.sql
 import java.sql.{Date, ResultSet, ResultSetMetaData, Time, Types}
 import java.time.{Instant, LocalDateTime, OffsetDateTime, OffsetTime}
+import java.util.Locale
 import java.util.UUID
 
 /**
@@ -39,7 +40,7 @@ class QueryResultRow private[classes](val rowNumber: Int,
 
   def columnCount: Int = fields.length
   def columnNumber(columnLabel: String): Int = {
-    val actualLabel = columnLabel.toLowerCase
+    val actualLabel = QueryResultRow.normalizeName(columnLabel)
     columnLabels.getOrThrow(actualLabel, new NoSuchElementException(s"Column '$actualLabel' not found"))
   }
 
@@ -148,13 +149,15 @@ object QueryResultRow {
   type Extractor = ResultSet => Option[Object]
   type Extractors = Vector[Extractor]
 
+  private[classes] def normalizeName(name: String): String = name.toLowerCase(Locale.ROOT)
+
   def apply(resultSet: ResultSet)(implicit fieldNames: FieldNames, extractors: Extractors): QueryResultRow = {
     val fields = extractors.map(_(resultSet))
     new QueryResultRow(resultSet.getRow, fields, fieldNames)
   }
 
   def fieldNamesFromMetadata(metaData: ResultSetMetaData): FieldNames = {
-    Range.inclusive(1, metaData.getColumnCount).map(i => metaData.getColumnName(i) -> i).toMap
+    Range.inclusive(1, metaData.getColumnCount).map(i => normalizeName(metaData.getColumnName(i)) -> i).toMap
   }
 
   def createExtractors(metaData: ResultSetMetaData): Extractors = {
@@ -186,4 +189,3 @@ object QueryResultRow {
   }
 
 }
-

--- a/balta/src/main/scala/za/co/absa/db/balta/classes/inner/Params.scala
+++ b/balta/src/main/scala/za/co/absa/db/balta/classes/inner/Params.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.db.balta.classes.inner
 
+import java.util.Locale
 import scala.collection.immutable.ListMap
 import za.co.absa.db.balta.typeclasses.{QueryParamValue, QueryParamType}
 
@@ -30,13 +31,15 @@ sealed abstract class Params private(items: ListMap[String, QueryParamValue]) {
   def values: List[QueryParamValue] = items.values.toList
 
   def apply(paramName: String): QueryParamValue = {
-    items(paramName)
+    items(Params.normalizeName(paramName))
   }
 
   def size: Int = items.size
 
 }
 object Params {
+  private[inner] def normalizeName(name: String): String = name.toLowerCase(Locale.ROOT)
+
 
   /**
    * This is a factory method for creating a list of named parameters consisting of one parameter identified by its
@@ -101,7 +104,7 @@ object Params {
      */
     def add[T: QueryParamType](paramName: String, value: T): NamedParams = {
       val queryValue = implicitly[QueryParamType[T]].toQueryParamValue(value)
-      new NamedParams(items + (paramName -> queryValue)) // TODO https://github.com/AbsaOSS/balta/issues/1
+      new NamedParams(items + (normalizeName(paramName) -> queryValue))
     }
 
     /**
@@ -155,4 +158,3 @@ object Params {
     override val keys: Option[List[String]] = None
   }
 }
-

--- a/balta/src/test/scala/za/co/absa/db/balta/classes/QueryResultRowUnitTests.scala
+++ b/balta/src/test/scala/za/co/absa/db/balta/classes/QueryResultRowUnitTests.scala
@@ -145,6 +145,18 @@ class QueryResultRowUnitTests extends AnyFunSuiteLike {
     assert(result == Map("id" -> 1, "name" -> 2))
   }
 
+  test("fieldNamesFromMetadata normalizes column names for case-insensitive lookup") {
+    val metaData = new StubMetaData(
+      List(("ID_FIELD", Types.INTEGER, "int4"), ("Text_Field", Types.VARCHAR, "varchar"))
+    )
+    val result = QueryResultRow.fieldNamesFromMetadata(metaData)
+    assert(result == Map("id_field" -> 1, "text_field" -> 2))
+
+    val row = mkRow(labels = result)
+    assert(row.columnNumber("ID_FIELD") == 1)
+    assert(row.columnNumber("text_FIELD") == 2)
+  }
+
   test("fieldNamesFromMetadata returns empty map for zero columns") {
     val metaData = new StubMetaData(Nil)
     val result = QueryResultRow.fieldNamesFromMetadata(metaData)

--- a/balta/src/test/scala/za/co/absa/db/balta/classes/inner/ParamsUnitTests.scala
+++ b/balta/src/test/scala/za/co/absa/db/balta/classes/inner/ParamsUnitTests.scala
@@ -69,6 +69,14 @@ class ParamsUnitTests extends AnyFunSuiteLike {
     assert(value.sqlEntry == "?")
   }
 
+  test("NamedParams treats parameter names case-insensitively") {
+    val params = Params.add("Param1", 1).add("PARAM1", 2)
+    assert(params.size == 1)
+    assert(params.keys.contains(List("param1")))
+    assert(params("param1").sqlEntry == "?")
+    assert(params("PARAM1").sqlEntry == "?")
+  }
+
   test("NamedParams apply throws NoSuchElementException for missing key") {
     val params = Params.add("id", 42)
     assertThrows[NoSuchElementException] {


### PR DESCRIPTION
## Summary
- normalize named query parameters with `Locale.ROOT` on insertion and lookup
- normalize result-set column names from metadata so mixed-case database labels can be accessed case-insensitively
- add regression tests for duplicate mixed-case parameter names and uppercase/mixed-case column metadata

## Verification
- `git diff --check`

Scala tests were not run locally because this environment does not have Java or sbt installed (`java` and `sbt` are not available on PATH).

Fixes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Column names and named parameters are now handled consistently regardless of letter casing.
  * Lookups now work even when names are entered with different capitalization.
  * Name matching now uses locale-stable lowercasing for more predictable behavior.

* **Tests**
  * Added coverage for case-insensitive column lookup.
  * Added coverage for case-insensitive named parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->